### PR TITLE
incorporate several includes for toc, headings, and getting help

### DIFF
--- a/_includes/challenge.md
+++ b/_includes/challenge.md
@@ -1,0 +1,2 @@
+## Challenge me
+### {{ include.text | default:'' }}

--- a/_includes/get-help.md
+++ b/_includes/get-help.md
@@ -1,0 +1,3 @@
+Do you have a question?  Want to share a resource?
+- Post to the [Data Librarians Slack group](https://tiny.cc/data-librarians) to connect with the community.
+- Tweet to [@ardc_au](https://twitter.com/ARDC_AU) using hashtag #23things

--- a/_includes/learn.md
+++ b/_includes/learn.md
@@ -1,0 +1,2 @@
+## Learn more
+### {{ include.text | default: '' }}

--- a/_includes/start.md
+++ b/_includes/start.md
@@ -1,0 +1,2 @@
+## Getting started
+### {{ include.text | default: '' }}

--- a/_includes/toc.md
+++ b/_includes/toc.md
@@ -1,0 +1,3 @@
+-   **[Getting started](#getting-started)** {{ include.start | default:'' }}
+-   **[Learn more](#learn-more)** {{ include.learn | default:'' }}
+-   **[Challenge me](#challenge-me)** {{ include.challenge | default:'' }}

--- a/things/thing-1.md
+++ b/things/thing-1.md
@@ -1,58 +1,35 @@
 ---
-HandheldFriendly: true
-author: ANDS
+author: ARDC
 description: |
-    Thing 1: Getting started with research data Research data comes in many
+    Getting started with research data Research data comes in many
     shapes and sizes. Kick off your research data journey and start sharing
     your stories. Getting started is for you if you are just beginning to
     learn about research data Learn more is if you know a bit but want to
     know more Challenge me is often more technical or assumes that you are
     familiar with at least the basics of managing and wrangling research
     data.
-keywords: 'Thing 1, Research data, data, research, research data, australia'
-og:description: |
-    Thing 1: Getting started with research data Research data comes in many
-    shapes and sizes. Kick off your research data journey and start sharing
-    your stories. Getting started is for you if you are just beginning to
-    learn about research data Learn more is if you know a bit but want to
-    know more Challenge me is often more technical or assumes that you are
-    familiar with at least the basics of managing and wrangling research
-    data.
-og:site_name: ANDS
-og:title: 'Thing 1: Getting started with research data'
-og:type: website
-og:url: 'https://www.ands.org.au/working-with-data/skills/23-research-data-things/all23/thing-1'
-robots: 'index,follow'
-title: 'Thing 1: Getting started with research data - ANDS'
-viewport: |
-    width=device-width, initial-scale=1.0, maximum-scale=1.0,
-    user-scalable=0
----
-# Thing 1: Getting started with research data
+title: 'Getting started with research data'
+thing: 1
+categories:
+    - "Ready, set, data"
 
+---
 **[Jump to Thing 2&gt;&gt;](thing-2.md)**
 
 Research data comes in many shapes and sizes. Kick off your research
 data journey and start sharing your stories.
 
--   **Getting started** is for you if you are just beginning to learn
-    about research data
--   **Learn more** is if you know a bit but want to know more
--   **Challenge me** is often more technical or assumes that you are
-    familiar with at least the basics of managing and wrangling research
-    data.
+{% include toc.md 
+    start="is for you if you are just beginning to learn"
+    learn="is if you know a bit but want to know more"
+    challenge="is often more technical or assumes that you are familiar with at least the basics of managing and wrangling research data." %}
 
 **Do I have to do them all?** No - you can pick'n'mix a different stream
 each week, or stay in the one stream. You can do as much or as little as
 you want to do, or need to know.
 
-* [Getting started](#getting-started)
-* [Learn more](#learn-more)
-* [Challenge me](#challenge-me)
 
-## Getting started
-
-### What is research data?
+{% include start.md text="What is research data?" %}
 
 What "research data" are we talking about?
 
@@ -77,16 +54,12 @@ What "research data" are we talking about?
 **Consider:** how the complexity and range of data formats affect access
 and reuse possibilities.
 
-Do you have a question?  Want to share a resource?
-- Post to the [Data Librarians Slack group](https://tiny.cc/data-librarians) to connect with the community.
-- Tweet to [@ardc_au](https://twitter.com/ARDC_AU) using \#23things
+{% include get-help.md %}
 
 Go to [Thing 2](thing-2.md "thing 2")
 Issues in research data management or to [All Things](index.md)
 
-## Learn more
-
-### Data across research disciplines
+{% include learn.md text="Data across research disciplines"}
 
 1\. Choose one of the four specialised data repositories below, or find
 another data repository of interest - particularly one in a discipline
@@ -106,16 +79,12 @@ with, for example, in format, size and access method.
 discipline data conventions, and also think about one way cross
 disciplinary data access can be facilitated.
 
-Do you have a question?  Want to share a resource?
-- Post to the [Data Librarians Slack group](https://tiny.cc/data-librarians) to connect with the community.
-- Tweet to [@ardc_au](https://twitter.com/ARDC_AU) using \#23things
+{% include get-help.md %}
 
 Go to [Thing 2](thing-2.md "thing 2")
 Issues in research data management or to [All Things](index.md)
 
-## Challenge me
-
-### Let's talk tech!
+{% include challenge.md text="Let's talk tech!"}
 
 Get the ball rolling to introduce yourself and expand awareness of the
 technical aspects to data management and this rapidly growing community
@@ -134,9 +103,7 @@ What is:
 **Consider:** a personal audit on what data technical skills you have,
 and what skills you want to learn.
 
-Do you have a question?  Want to share a resource?
-- Post to the [Data Librarians Slack group](https://tiny.cc/data-librarians) to connect with the community.
-- Tweet to [@ardc_au](https://twitter.com/ARDC_AU) using \#23things
+{% include get-help.md %}
 
 ### Ready, set, data
 

--- a/things/thing-10.md
+++ b/things/thing-10.md
@@ -1,42 +1,24 @@
 ---
-HandheldFriendly: true
-author: ANDS
+author: ARDC
 description: |
     Sharing sensitive data requires careful consideration, but it can be done.  Find out how.
 keywords: 'data, research, research data, australia'
-og:description: |
-    Sharing sensitive data requires careful consideration, but it can be done.  Find out how.
-og:site_name: ANDS
-og:title: 'Thing 10: Sharing sensitive data'
-og:type: website
-og:url: 'https://www.ands.org.au/working-with-data/skills/23-research-data-things/all23/thing-10'
-robots: 'index,follow'
-title: 'Thing 10: Sharing sensitive data - ANDS'
-viewport: |
-    width=device-width, initial-scale=1.0, maximum-scale=1.0,
-    user-scalable=0
+title: 'Sharing sensitive data'
+thing: 10
+categories:
+    - "Rights, ethics & sensitive data"
 ---
-
-#Thing 10: Sharing sensitive data
-
 **[&lt;&lt;Jump to Thing 9](thing-9.md) &nbsp; &nbsp; [Jump to Thing 11&gt;&gt;](thing-11.md)**
 
 Sharing sensitive data requires careful consideration, but it can be
 done.  Find out how.
 
--   **Getting started:** If it’s so sensitive - how can it possibly be
-    shared and published?!
--   **Learn more:** Who are the “data gatekeepers”?
--   **Challenge me:** Make me anonymous
+{% include toc.md 
+    start="If it’s so sensitive - how can it possibly be shared and published?!"
+    learn='Who are the “data gatekeepers”?'
+    challenge="Make me anonymous" %}
 
-
-* [Getting started](#getting-started)
-* [Learn more](#learn-more)
-* [Challenge me](#challenge-me)
-
-## Getting started 
-
-### Sensitive data *can* be shared!
+{% include start.md text="Sensitive data *can* be shared!" %}
 
 Major, familiar, categories of sensitive data are
 **human data** (eg health and personal data, secret or sacred practices); or
@@ -81,16 +63,12 @@ survey:
     world to see”?
 
 
-Do you have a question?  Want to share a resource?
-- Post to the [Data Librarians Slack group](https://tiny.cc/data-librarians) to connect with the community.
-- Tweet to [@ardc_au](https://twitter.com/ARDC_AU) using hashtag #23things
+{% include get-help.md %}
 
 Go to [Thing 11](thing-11.md)
 What's my metadata schema? or to [All Things](index.md)
 
-## Learn more
-
-### The ethics of sensitive data
+{% include learn.md text="The ethics of sensitive data" %}
 
 How we manage sensitive data through its lifecycle and who has a role in
 ensuring sensitive data is appropriately managed and shared are critical
@@ -115,17 +93,13 @@ discussion or workshop.
 based on a research project you a familiar with.
 
 
-Do you have a question?  Want to share a resource?
-- Post to the [Data Librarians Slack group](https://tiny.cc/data-librarians) to connect with the community.
-- Tweet to [@ardc_au](https://twitter.com/ARDC_AU) using hashtag #23things
+{% include get-help.md %}
 
 Go to [Thing 11](thing-11.md)
 What's my metadata schema? or to [All Things](index.md)
 
 
-## Challenge me
-
-### Anonymising sensitive data
+{% include challenge.md text="Anonymising sensitive data" %}
 
 
 De-identification (also called anonymisation or confidentialisation in
@@ -148,9 +122,7 @@ findings or endangered species.
 **Consider:** What types of data are there for which de-identification
 might not be needed or appropriate?
 
-Do you have a question?  Want to share a resource?
-- Post to the [Data Librarians Slack group](https://tiny.cc/data-librarians) to connect with the community.
-- Tweet to [@ardc_au](https://twitter.com/ARDC_AU) using hashtag #23things
+{% include get-help.md %}
 
 Go to [Thing 11](thing-11.md)
 What's my metadata schema? or to [All Things](index.md)

--- a/things/thing-12.md
+++ b/things/thing-12.md
@@ -1,27 +1,15 @@
 ---
-HandheldFriendly: true
-author: ANDS
+author: ARDC
 description: |
     Data descriptor, keyword, subject … these are all terms commonly used
     when discussing metadata.  Learn about the use of controlled
     vocabularies to enhance data discovery.
 keywords: 'data, research, research data, australia'
-og:description: |
-    Data descriptor, keyword, subject … these are all terms commonly used
-    when discussing metadata.  Learn about the use of controlled
-    vocabularies to enhance data discovery.
-og:site_name: ANDS
-og:title: 'Thing 12: Vocabularies for data description'
-og:type: website
-og:url: 'https://www.ands.org.au/working-with-data/skills/23-research-data-things/all23/thing-12'
-robots: 'index,follow'
-title: 'Thing 12: Vocabularies for data description - ANDS'
-viewport: |
-    width=device-width, initial-scale=1.0, maximum-scale=1.0,
-    user-scalable=0
+title: 'Vocabularies for data description'
+thing: 12
+categories:
+    - "Metadata & more"
 ---
-
-#Thing 12: Vocabularies for data description
 
 **[&lt;&lt;Jump to Thing 11](thing-11.md) &nbsp; &nbsp; [Jump to Thing 13&gt;&gt;](thing-13.md)**
 
@@ -29,20 +17,12 @@ Data descriptor, keyword, subject … these are all terms commonly used
 when discussing metadata.  Learn about the use of controlled
 vocabularies to enhance data discovery.
 
--   **Get started:** Control your language, please!
--   **Learn more**: Make a contribution to Research Vocabularies
-    Australia
--   **Challenge me**: KWA - the CSIRO  Science Keyword Aggregator - a
-    service and widget
+{% include toc.md 
+    start="Control your language, please!"
+    learn="Make a contribution to Research Vocabularies Australia"
+    challenge="KWA - the CSIRO  Science Keyword Aggregator - a service and widget" %}
 
-
-* [Getting started](#getting-started)
-* [Learn more](#learn-more)
-* [Challenge me](#challenge-me)
-
-## Getting started: 
-
-### Controlled vocabularies for data description
+{% include start.md text="Controlled vocabularies for data description" %}
 
 In addition to selecting a metadata standard or schema, whenever
 possible you should also use a controlled vocabulary. A controlled
@@ -75,16 +55,12 @@ Australia](http://www.ala.org.au/ "ALA").
 **Consider:** How do you think we could encourage people to use
 controlled vocabularies in their data descriptions?
 
-Do you have a question?  Want to share a resource?
-- Post to the [Data Librarians Slack group](https://tiny.cc/data-librarians) to connect with the community.
-- Tweet to [@ardc_au](https://twitter.com/ARDC_AU) using hashtag #23things
+{% include get-help.md %}
 
 Go to [Thing 13](thing-13.md "Thing 13")
 Walk the crosswalk or to [All Things](index.md)
 
-## Learn more
-
-### What controlled vocabularies exist?
+{% include learn.md text="What controlled vocabularies exist?" %}
 
 Think about (or find out!) what standard vocabularies are used, or could
 be used, by research groups in a discipline which interests you. Note
@@ -103,17 +79,13 @@ vocabulary is included.
 **Consider:** why your vocabulary should (or shouldn't) be included in
 RVA.
 
-Do you have a question?  Want to share a resource?
-- Post to the [Data Librarians Slack group](https://tiny.cc/data-librarians) to connect with the community.
-- Tweet to [@ardc_au](https://twitter.com/ARDC_AU) using hashtag #23things
+{% include get-help.md %}
 
 Go to [Thing 13](thing-13.md "Thing 13")
 Walk the crosswalk or to [All Things](index.md)
 
 
-## Challenge me 
-
-### Supporting multiple vocabularies
+{% include challenge.md text="Supporting multiple vocabularies" %}
 
 The Science Keyword Aggregator has been developed by CSIRO and released
 as open source to allow others to adapt and reuse. It is a service that
@@ -136,9 +108,7 @@ embed in their application and thus provide a term search there.
 **Consider:** Is this a tool that could be implemented in your
 organisation? How would you use it?
 
-Do you have a question?  Want to share a resource?
-- Post to the [Data Librarians Slack group](https://tiny.cc/data-librarians) to connect with the community.
-- Tweet to [@ardc_au](https://twitter.com/ARDC_AU) using hashtag #23things
+{% include get-help.md %}
 
 Go to [Thing 13](thing-13.md "Thing 13")
 Walk the crosswalk or to [All Things](index.md)

--- a/things/thing-15.md
+++ b/things/thing-15.md
@@ -1,47 +1,31 @@
 ---
-HandheldFriendly: true
-author: ANDS
+author: ARDC
 description: |
-    Thing 15: Some research institutions and research funders now require researchers
+    Some research institutions and research funders now require researchers
     to submit a Data Management Plan (DMP) for new projects. What should a
     DMP cover? Could you help with one?
 keywords: 'data, research, research data, australia'
-og:description: |
-    Thing 15: Some research institutions and research funders now require researchers
-    to submit a Data Management Plan (DMP) for new projects. What should a
-    DMP cover? Could you help with one?
-og:site_name: ANDS
-og:title: 'Thing 15: Data management plans'
-og:type: website
-og:url: 'https://www.ands.org.au/working-with-data/skills/23-research-data-things/all23/thing-15'
-robots: 'index,follow'
-title: 'Thing 15: Data management plans - ANDS'
-viewport: |
-    width=device-width, initial-scale=1.0, maximum-scale=1.0,
-    user-scalable=0
+title: 'Data management plans'
+thing: 15
+categories:
+    - "Let's talk data"
 ---
-# Thing 15: Data management plans
-
 **[&lt;&lt;Jump to Thing 14](thing-14.md) &nbsp; &nbsp; [Jump to Thing 16&gt;&gt;](thing-16.md)**
 
 Some research institutions and research funders now require researchers
 to submit a Data Management Plan (DMP) for new projects. What should a
 DMP cover? Could you help with one?
 
--   **Getting started**: What’s a DMP?
--   **Learn more**: Why machine-actionable DMPs?
--   **Challenge me**: Exploring DMP Tools
+
+{% include toc.md 
+    start="What’s a DMP?"
+    learn="Why machine-actionable DMPs?"
+    challenge="Exploring DMP Tools" %}
 
 [Find out about the work of the Australasian DMP Interest
 Group](http://tiny.cc/DMP-IG)
 
-* [Getting started](#getting-started)
-* [Learn more](#learn-more)
-* [Challenge me](#challenge-me)
-
-## Getting started 
-
-### An introduction to Data Management Plans
+{% include start.md text="An introduction to Data Management Plans" %}
 
 A Data Management Plan (DMP) documents how data will be managed, stored
 and shared during and after a research project. Some research funders
@@ -62,16 +46,12 @@ project proposal.
 extremely long and complex. What do you think are the two or three
 pieces of information essential to include in every DMP and why?
 
-Do you have a question?  Want to share a resource?
-- Post to the [Data Librarians Slack group](https://tiny.cc/data-librarians) to connect with the community.
-- Tweet to [@ardc_au](https://twitter.com/ARDC_AU) using hashtag#23things
+{% include get-help.md %}
 
 Go to [Thing 16](thing-16.md)
 What are Publishers and Funders saying about data? or to [All Things](index.md)
 
-## Learn more
-
-### Templates for Data Management Plans
+{% include learn.md text="Templates for Data Management Plans" %}
 
 Imagine if the information contained in a DMP could flow across other
 systems automatically (e.g. to populate faculty profiles, monitor
@@ -101,16 +81,12 @@ definition](https://www.ddialliance.org/taxonomy/term/198)).
 **Consider:** Do you think machine-actionable DMPs will make them more
 valuable to researchers? Institutions? Funders?
 
-Do you have a question?  Want to share a resource?
-- Post to the [Data Librarians Slack group](https://tiny.cc/data-librarians) to connect with the community.
-- Tweet to [@ardc_au](https://twitter.com/ARDC_AU) using hashtag#23things
+{% include get-help.md %}
 
 Go to [Thing 16](thing-16.md)
 What are Publishers and Funders saying about data? or to [All Things](index.md)
 
-## Challenge me 
-
-### Data Management Plans for the Humanities
+{% include challenge.md text="Data Management Plans for the Humanities" %}
 
 1.  First have a look at the [The DMPTool: A Brief Overview 90 sec
     video](https://www.youtube.com/watch?v=xT1by-p5jUw&feature=youtu.be "DMP overview video")
@@ -132,9 +108,7 @@ goals or further enhancements?
 [Find out about the work of the Australasian DMP Interest
 Group](http://tiny.cc/DMP-IG)
 
-Do you have a question?  Want to share a resource?
-- Post to the [Data Librarians Slack group](https://tiny.cc/data-librarians) to connect with the community.
-- Tweet to [@ardc_au](https://twitter.com/ARDC_AU) using hashtag#23things
+{% include get-help.md %}
 
 Go to [Thing 16](thing-16.md)
 What are Publishers and Funders saying about data? or to [All Things](index.md)

--- a/things/thing-4.md
+++ b/things/thing-4.md
@@ -1,55 +1,30 @@
 ---
-HandheldFriendly: true
-author: ANDS
+author: ARDC
 description: |
-    Thing 4: Data discovery Repositories enable discovery of data by
-    publishing data descriptions ("metadata") about the data they hold -
-    like a library catalogue describes the materials held in a library. Most
-    repositories provide access to the data itself, but not always. Data
-    portals or aggregators draw together research data records from a number
-    of repositories. eg Research Data Australia (RDA) aggregates records
-    from over 100 Australian research repositories.
+    Repositories enable discovery of data by publishing data
+    descriptions ("metadata") about the data they hold - like a library 
+    catalogue describes the materials held in a library. Most repositories 
+    provide access to the data itself, but not always. Data portals or 
+    aggregators draw together research data records from a number of 
+    repositories. eg Research Data Australia (RDA) aggregates records from 
+    over 100 Australian research repositories.
 keywords: 'data sharing, Thing 4, data, research, research data, australia'
-og:description: |
-    Thing 4: Data discovery Repositories enable discovery of data by
-    publishing data descriptions ("metadata") about the data they hold -
-    like a library catalogue describes the materials held in a library. Most
-    repositories provide access to the data itself, but not always. Data
-    portals or aggregators draw together research data records from a number
-    of repositories. eg Research Data Australia (RDA) aggregates records
-    from over 100 Australian research repositories.
-og:site_name: ANDS
-og:title: 'Thing 4: Data discovery'
-og:type: website
-og:url: 'https://www.ands.org.au/working-with-data/skills/23-research-data-things/all23/thing-4'
-robots: 'index,follow'
-title: 'Thing 4: Data discovery - ANDS'
-viewport: |
-    width=device-width, initial-scale=1.0, maximum-scale=1.0,
-    user-scalable=0
+title: 'Data discovery'
+thing: 4
+categories:
+    - "Repositories for data"
 ---
-#Thing 4: Data Discovery
-
 **[&lt;&lt;Jump to Thing 3](thing-3.md) &nbsp; &nbsp; [Jump to Thing 5&gt;&gt;](thing-5.md)**
 
 Repositories and portals play an important role in making research data
 discoverable and accessible.
 
--   **Getting started:** explore Research Data Australia to find
-    research data
--   **Learn more:** what's in (and what's not in) the 2,000+ data
-    repositories in re3data?
--   **Challenge me:** can we Trust that repository and how would we
-    know?
+{% include toc.md 
+    start="explore Research Data Australia to find research data"
+    learn="what's in (and what's not in) the 2,000+ data repositories in re3data?"
+    challenge="can we Trust that repository and how would we know?" %}
 
-
-* [Getting started](#getting-started)
-* [Learn more](#learn-more)
-* [Challenge me](#challenge-me)
-
-## Getting started 
-
-### Repositories for data discovery
+{% include start.md text="Repositories for data discovery" %}
 
 Repositories enable discovery of data by publishing data descriptions
 ("metadata") about the data they hold - like a library catalogues
@@ -80,16 +55,12 @@ records from over 100 Australian repositories.
 **Consider:** the future impact of having a national research data
 catalogue.
 
-Do you have a question?  Want to share a resource?
-- Post to the [Data Librarians Slack group](https://tiny.cc/data-librarians) to connect with the community.
-- Tweet to [@ardc_au](https://twitter.com/ARDC_AU) using hashtag#23things
+{% include get-help.md %}
 
 Go to [Thing 5](thing-5.md)
 Data sharing or to [All Things](index.md)
 
-## Learn More 
-
-### Finding data repositories
+{% include learn.md text="Finding data repositories" %}
 
 What data repositories exist and how are Australian researchers sharing
 their data?
@@ -104,16 +75,12 @@ their data?
 Australia's research data repositories, and the data records they
 contain, could be achieved.
 
-Do you have a question?  Want to share a resource?
-- Post to the [Data Librarians Slack group](https://tiny.cc/data-librarians) to connect with the community.
-- Tweet to [@ardc_au](https://twitter.com/ARDC_AU) using hashtag#23things
+{% include get-help.md %}
 
 Go to [Thing 5](thing-5.md)
 Data sharing or to [All Things](index.md)
 
-## Challenge me
-
-### Evaluating data repositories
+{% include challenge.md text="Evaluating data repositories" %}
 
 What makes a "good" data repository?
 
@@ -131,9 +98,7 @@ Have a look at one or both of these resources:
 repositories: have you used either or both of these resources? Would
 you?
 
-Do you have a question?  Want to share a resource?
-- Post to the [Data Librarians Slack group](https://tiny.cc/data-librarians) to connect with the community.
-- Tweet to [@ardc_au](https://twitter.com/ARDC_AU) using hashtag#23things
+{% include get-help.md %}
 
 Go to [Thing 5](thing-5.md)
 Data sharing or to [All Things](index.md)

--- a/things/thing-5.md
+++ b/things/thing-5.md
@@ -1,44 +1,26 @@
 ---
-HandheldFriendly: true
-author: ANDS
+author: ARDC
 description: |
-    Thing 5: Data sharing Introducing 'open', 'shared' and 'closed' data.
-    This activity explains why different datasets may have different access
-    conditions.
+    Introducing 'open', 'shared' and 'closed' data. This activity explains
+    why different datasets may have different access conditions.
 keywords: |
     Thing 5, open data, shared data, closed data,data, research, research
     data, australia
-og:description: |
-    Thing 5: Data sharing Introducing 'open', 'shared' and 'closed' data.
-    This activity explains why different datasets may have different access
-    conditions.
-og:site_name: ANDS
-og:title: 'Thing 5: Data sharing'
-og:type: website
-og:url: 'https://www.ands.org.au/working-with-data/skills/23-research-data-things/all23/thing-5'
-robots: 'index,follow'
-title: 'Thing 5: Data sharing - ANDS'
-viewport: |
-    width=device-width, initial-scale=1.0, maximum-scale=1.0,
-    user-scalable=0
+title: 'Data sharing'
+thing: 5
+categories: 
+    - "Repositories for data"
 ---
-# Thing 5: Data sharing
-
 **<<[Jump to Thing 4](thing-4.md) [Jump to Thing 5](thing-6.md)>>**
 
 Research data may be shared in many ways.  This week we look at 3 ways:
 
-1.  **Getting started** looks at sharing data via access methods: Open,
-    Shared and Closed Data
-2.  **Learn more** explores data sharing trends of some countries and by
-    disciplines
-3.  **Challenge me** dips into ensuring that data can be shared for a
-    long time via some preservation tools
+{% include toc.md 
+    start="looks at sharing data via access methods: Open, Shared and Closed Data"
+    learn="explores data sharing trends of some countries and by disciplines"
+    challenge="dips into ensuring that data can be shared for a long time via some preservation tools" %}
 
-
-## Getting started
-
-### Access to research data
+{% include start.md text="Access to research data" %}
 
 Introducing 'open', 'shared' and 'closed' data.
 
@@ -58,15 +40,11 @@ access conditions.
 
 **Consider:** why more data isn't publicly accessible or more 'open'.
 
-Do you have a question?  Want to share a resource?
-- Post to the [Data Librarians Slack group](https://tiny.cc/data-librarians) to connect with the community.
-- Tweet to [@ardc_au](https://twitter.com/ARDC_AU) using hashtag #23things
+{% include get-help.md %}
 
 Go to [Thing 6:](thing-6.md) "Long-lived data: curation & preservation" or to [All Things](index.md)
 
-## Learn more
-
-### Data sharing practices
+{% include learn.md text="Data sharing practices" %}
 
 Repositories are one means by which research data may be shared.
 
@@ -77,14 +55,11 @@ Repositories are one means by which research data may be shared.
 and countries - what changes to these statistics would you expect
 between 2014 and now?
 
-Do you have a question?  Want to share a resource?
-- Post to the [Data Librarians Slack group](https://tiny.cc/data-librarians) to connect with the community.
-- Tweet to [@ardc_au](https://twitter.com/ARDC_AU) using hashtag #23things
+{% include get-help.md %}
 
 Go to [Thing 6:](thing-6.md) "Long-lived data: curation & preservation" or to [All Things](index.md)
 
-## Challenge me
-### Tools to preserve research data
+{% include challenge.md text="Tools to preserve research data" %}
 
 Data sharing is only a long term prospect if repositories have
 preservation as part of their workflows and procedures.
@@ -103,9 +78,7 @@ need to preserve digital data.
 **Consider:** Have you, or would you, use any of these tools? How
 feasible it is to expect such preservation tools to be widely used?
 
-Do you have a question?  Want to share a resource?
-- Post to the [Data Librarians Slack group](https://tiny.cc/data-librarians) to connect with the community.
-- Tweet to [@ardc_au](https://twitter.com/ARDC_AU) using hashtag #23things
+{% include get-help.md %}
 
 Go to [Thing 6:](thing-6.md) "Long-lived data: curation & preservation" or to [All Things](index.md)
 

--- a/things/thing-6.md
+++ b/things/thing-6.md
@@ -1,50 +1,29 @@
 ---
-HandheldFriendly: true
-author: ANDS
+author: ARDC
 description: |
-    Thing 6: Long-lived data: curation & preservation Traditional
-    information sources such as books, photos and sculptures can easily
-    survive for years, decades or even centuries but digital items require
-    special care to keep them usable over time. Ensuring data stays
+    Traditional information sources such as books, photos and sculptures can 
+    easily survive for years, decades or even centuries but digital items 
+    require special care to keep them usable over time. Ensuring data stays
     accessible and reusable into the future. Learn about the curation of
     data and try out a free tool for managing file formats.
 keywords: 'Thing 6, reusable data, data, research, research data, australia'
-og:description: |
-    Thing 6: Long-lived data: curation & preservation Traditional
-    information sources such as books, photos and sculptures can easily
-    survive for years, decades or even centuries but digital items require
-    special care to keep them usable over time. Ensuring data stays
-    accessible and reusable into the future. Learn about the curation of
-    data and try out a free tool for managing file formats.
-og:site_name: ANDS
-og:title: 'Thing 6: Long-lived data: curation &amp; preservation'
-og:type: website
-og:url: 'https://www.ands.org.au/working-with-data/skills/23-research-data-things/all23/thing-6'
-robots: 'index,follow'
-title: 'Thing 6: Long-lived data: curation & preservation - ANDS'
-viewport: |
-    width=device-width, initial-scale=1.0, maximum-scale=1.0,
-    user-scalable=0
-
+title: 'Long-lived data: curation & preservation'
+thing: 6
+categories:
+    - ""
 ---
-
-# Thing 6: Long-lived data: curation & preservation
-
 **<<[Jump to Thing 5](thing-5.md) [Jump to Thing 7](thing-7.md)>>**
 
 Ensuring data stays accessible and reusable into the future.  Learn
 about the curation of data and try out a free tool for managing file
 formats.
 
-1.  **Getting started:** how would you advise someone what to do to make
-    sure their fragile born digital data is robust and long lived?
-2.  **Learn more:** how does archiving, preserving and curating data
-    "Stack" up?
-3.  **Challenge me:** what's in a (PRO)NOM?
+{% include toc.md 
+    start="how would you advise someone what to do to make sure their fragile born digital data is robust and long lived?"
+    learn='how does archiving, preserving and curating data "Stack" up?'
+    challenge="what's in a (PRO)NOM?" %}
 
-
-## Getting started
-### Preserving born digital objects
+{% include start.md text="Preserving born digital objects" %}
 
 Traditional information sources such as books, photos and maps can
 easily survive for years, decades or even centuries but digital items
@@ -61,14 +40,11 @@ require special care to keep them usable over time.
 their born digital objects. For example the family historian, a
 researcher, yourself?
 
-Do you have a question?  Want to share a resource?
-- Post to the [Data Librarians Slack group](https://tiny.cc/data-librarians) to connect with the community.
-- Tweet to [@ardc_au](https://twitter.com/ARDC_AU) using hashtag #23things
+{% include get-help.md %}
 
 Go to [Thing 7](thing-7.md) Data citation for access & attribution or to [All Things](index.md)
 
-## Learn more
-### A model for data curation, preservation and archiving
+{% include learn.md text="A model for data curation, preservation and archiving" %}
 
 ‘Curation’, ‘preservation’, ‘archiving’ … are all commonly used data
 management terms.  Are they all the same thing?
@@ -82,15 +58,12 @@ and curation.
 **Consider:** What do you think about the Stack Model and its relevance
 for data repositories?
 
-Do you have a question?  Want to share a resource?
-- Post to the [Data Librarians Slack group](https://tiny.cc/data-librarians) to connect with the community.
-- Tweet to [@ardc_au](https://twitter.com/ARDC_AU) using hashtag #23things
+{% include get-help.md %}
 
 Go to [Thing 7](thing-7.md)
 Data citation for access & attribution or to [All Things](index.md)
 
-## Challenge me
-### Tools to preserve research data
+{% include challenge.md text="Tools to preserve research data" %}
 
 Data managers often refer to ‘long-lived data formats’, ‘open file
 formats’ and ‘format migration’. The UK National Archives has made
@@ -122,9 +95,7 @@ to profile a small number of files.
 
 **Consider:** Are PRONOM and DROID tools you'd like to explore further?
 
-Do you have a question?  Want to share a resource?
-- Post to the [Data Librarians Slack group](https://tiny.cc/data-librarians) to connect with the community.
-- Tweet to [@ardc_au](https://twitter.com/ARDC_AU) using hashtag #23things
+{% include get-help.md %}
 
 Go to [Thing 7](thing-7.md)
 Data citation for access & attribution or to [All Things](index.md)

--- a/things/thing-7.md
+++ b/things/thing-7.md
@@ -1,46 +1,27 @@
 ---
-HandheldFriendly: true
-author: ANDS
+author: ARDC
 description: |
-    Thing 7: Data citation for access & attribution. Citation analysis and
-    citation metrics are important to the academic community. Find out where
-    data fits in the citation picture.
+    Citation analysis and citation metrics are important to the academic
+    community. Find out where data fits in the citation picture.
 keywords: |
     Thing 7, data citation, citation analysis, citation metrics,data,
     research, research data, australia
-og:description: |
-    Thing 7: Data citation for access & attribution. Citation analysis and
-    citation metrics are important to the academic community. Find out where
-    data fits in the citation picture.
-og:site_name: ANDS
-og:title: 'Thing 7: Data citation for access &amp; attribution'
-og:type: website
-og:url: 'https://www.ands.org.au/working-with-data/skills/23-research-data-things/all23/thing-7'
-robots: 'index,follow'
-title: 'Thing 7: Data citation for access & attribution - ANDS'
-viewport: |
-    width=device-width, initial-scale=1.0, maximum-scale=1.0,
-    user-scalable=0
+title: 'Data citation for access & attribution'
+thing: 7
+categories:
+    - "Data citation & impact"
 ---
-#Thing 7: Data citation for access & attribution
-
 **[&lt;&lt;Jump to Thing 6](thing-6.md) &nbsp; &nbsp; [Jump to Thing 8&gt;&gt;](thing-8.md)**
 
 Citation analysis and citation metrics are important to the academic
 community. Find out where data fits in the citation picture.
 
--   **Getting started**: how to cite data
--   **Learn more**: may the FORCE(11) be with you (while you cite data)
--   **Challenge me**: are some data formats more likely to be cited?
+{% include toc.md 
+    start="how to cite data"
+    learn="may the FORCE(11) be with you (while you cite data)"
+    challenge="are some data formats more likely to be cited?" %}
 
-
-* [Getting started](#getting-started)
-* [Learn more](#learn-more)
-* [Challenge me](#challenge-me)
-
-## Getting started 
-
-### Citing research data
+{% include start.md text="Citing research data" %}
 
 Data citation continues the tradition of acknowledging other people’s
 work and ideas. Along with books, journals and other scholarly works, it
@@ -74,18 +55,12 @@ landscape and as yet, is not routinely done by researchers, or expected
 by most journals. What could be done to encourage routine citation of
 research data and software associated with research outputs?
 
-
-Do you have a question?  Want to share a resource?
-- Post to the [Data Librarians Slack group](https://tiny.cc/data-librarians) to connect with the community.
-- Tweet to [@ardc_au](https://twitter.com/ARDC_AU) using hashtag#23things
+{% include get-help.md %}
 
 Go to [Thing 8](thing-8.md)
 Citation metrics for data or to [All Things](index.md)
 
-## Learn more
-
-# Data citation principles
-
+{% include learn.md text="Data citation principles" %}
 
 The Force11 Joint Declaration of Data Citation Principles are a set of
 principles for citing data. They are based on the premise that data
@@ -105,16 +80,12 @@ individuals and more than 100 data centres, publishers and societies.
 data citation has not been uniformly adopted, so far, across all
 disciplines?
 
-Do you have a question?  Want to share a resource?
-- Post to the [Data Librarians Slack group](https://tiny.cc/data-librarians) to connect with the community.
-- Tweet to [@ardc_au](https://twitter.com/ARDC_AU) using hashtag#23things
+{% include get-help.md %}
 
 Go to [Thing 8](thing-8.md)
 Citation metrics for data or to [All Things](index.md)
 
-## Challenge me 
-
-### Data formats and data citation
+{% include challenge.md text="Data formats and data citation" %}
 
 Are some data formats more likely to be cited?
 
@@ -142,10 +113,7 @@ passenger dataset they have provided.
 is likely to make the data more or less accessible, reusable and
 therefore citable?
 
-
-Do you have a question?  Want to share a resource?
-- Post to the [Data Librarians Slack group](https://tiny.cc/data-librarians) to connect with the community.
-- Tweet to [@ardc_au](https://twitter.com/ARDC_AU) using hashtag#23things
+{% include get-help.md %}
 
 Go to [Thing 8](thing-8.md)
 Citation metrics for data or to [All Things](index.md)

--- a/things/thing-8.md
+++ b/things/thing-8.md
@@ -1,45 +1,29 @@
 ---
-HandheldFriendly: true
-author: ANDS
+author: ARDC
 description: |
-    The Australian National Data Service (ANDS) is a program funded by the
-    Australian Government to develop research data infrastructure and enable
-    more effective use of Australia's research data assets.
+    What are Digital Object Identifiers (DOIs) and how do they support data
+    citation and metrics for data and related research objects?
 keywords: 'data, research, research data, australia'
-og:description: |
-    The Australian National Data Service (ANDS) is a program funded by the
-    Australian Government to develop research data infrastructure and enable
-    more effective use of Australia's research data assets.
-og:site_name: ANDS
-og:title: 'Thing 8: DOIs and citation metrics for data'
-og:type: website
-og:url: 'https://www.ands.org.au/working-with-data/skills/23-research-data-things/all23/thing-8'
-robots: 'index,follow'
-title: 'Thing 8: DOIs and citation metrics for data - ANDS'
-viewport: |
-    width=device-width, initial-scale=1.0, maximum-scale=1.0,
-    user-scalable=0
+title: 'DOIs and citation metrics for data'
+thing: 8
+categories:
+    - "Data citation & impact"
 ---
-
 **<<[Jump to Thing 7](thing-7.md "Thing 7") [Jump to Thing 9](thing-9.md "Thing 9")>>**
-
-# Thing 8 - DOIs and citation metrics for data
 
 What are Digital Object Identifiers (DOIs) and how do they support data
 citation and metrics for data and related research objects?
 
--   **Getting started**: what are DOIs and why are they critical for
-    accurate citation metrics?
--   **Learn more**: delves into altmetrics (and donuts!)
--   **Challenge me**: what about minting DOIs for software, algorithms
-    and grey literature?
+{% include toc.md 
+    start="what are DOIs and why are they critical for accurate citation metrics?"
+    learn="delves into altmetrics (and donuts!)"
+    challenge="what about minting DOIs for software, algorithms and grey literature?" %}
 
 **Did you know?** You don't need to do all three streams, or even stay
 in the same stream. 23 Things is about picking which Things and streams
 you want to explore or know more about.
 
-
-## Getting started: DOIs, data citation and metrics
+{% include start.md text="DOIs, data citation and metrics" %}
 
 Digital Object Identifiers (DOIs) are unique identifiers that provide
 persistent access to published articles, datasets, software versions and
@@ -78,14 +62,11 @@ or article.
     <http://dx.doi.org/10.4227/11/50459F7BD4D0B> in the NSW Archaeology
     Online: Grey Literature Archive.
 
-Do you have a question?  Want to share a resource?
-- Post to the [Data Librarians Slack group](https://tiny.cc/data-librarians) to connect with the community.
-- Tweet to [@ardc_au](https://twitter.com/ARDC_AU) using hashtag #23things
+{% include get-help.md %}
 
 Go to [Thing 9](thing-9.md) Licensing data for reuse or to [All Things](index.md)
 
-
-## Learn more: Who cares about (alt)metrics?
+{% include learn.md text="Who cares about (alt)metrics?" %}
 
 Alternative metrics or "altmetrics" count the number of views, number of
 downloads, social media "likes" and recommendations associated with a
@@ -116,13 +97,11 @@ By way of comparison, as of early November 2018:
 **Consider:** Do you think altmetrics for data have value in academic
 settings?  Why, or why not?
 
-Do you have a question?  Want to share a resource?
-- Post to the [Data Librarians Slack group](https://tiny.cc/data-librarians) to connect with the community.
-- Tweet to [@ardc_au](https://twitter.com/ARDC_AU) using hashtag #23things
+{% include get-help.md %}
 
 Go to [Thing 9](thing-9.md) Licensing data for reuse or to [All Things](index.md)
 
-## Challenge me: Minting' DOIs for research data
+{% include challenge.md text="Minting DOIs for research data"%}
 
 The ANDS DOI service (Cite My Data) enables research organisations to
 assign Digital Object Identifiers (DOIs) to research datasets and
@@ -156,9 +135,7 @@ through the
 **Consider:** What do you think are the critical issues to ensure the
 persistence of DOIs over a number of years?
 
-Do you have a question?  Want to share a resource?
-- Post to the [Data Librarians Slack group](https://tiny.cc/data-librarians) to connect with the community.
-- Tweet to [@ardc_au](https://twitter.com/ARDC_AU) using hashtag #23things
+{% include get-help.md %}
 
 Go to [Thing 9](thing-9.md) Licensing data for reuse or to [All Things](index.md)
 

--- a/things/thing-9.md
+++ b/things/thing-9.md
@@ -1,43 +1,25 @@
 ---
-HandheldFriendly: true
-author: ANDS
+author: ARDC
 description: |
     Understand the importance of data licensing and learn about Creative
     Commons.
 keywords: 'data, research, research data, australia'
-og:description: |
-    Understand the importance of data licensing and learn about Creative
-    Commons.
-og:site_name: ANDS
-og:title: 'Thing 9: Licensing data for reuse'
-og:type: website
-og:url: 'https://www.ands.org.au/working-with-data/skills/23-research-data-things/all23/thing-9'
-robots: 'index,follow'
-title: 'Thing 9: Licensing data for reuse - ANDS'
-viewport: |
-    width=device-width, initial-scale=1.0, maximum-scale=1.0,
-    user-scalable=0
+title: 'Licensing data for reuse'
+thing: 9
+categories:
+    - "Rights, ethics & sensitive data"
 ---
-# Thing 9: Licensing data for reuse
-
 **[&lt;&lt;Jump to Thing 8](thing-8.md) &nbsp; &nbsp; [Jump to Thing 10&gt;&gt;](thing-10.md)**
 
 Understand the importance of data licensing and learn about Creative
 Commons.
 
--   **Getting started**: don’t let CC pass you BY!
--   **Learn more**: Licensing - a keystone for innovation and business
--   **Challenge me**: How does Licensing work in tricky or complex
-    situations?
+{% include toc.md 
+    start="don’t let CC pass you BY!"
+    learn="Licensing - a keystone for innovation and business"
+    challenge="How does Licensing work in tricky or complex situations?" %}
 
-
-* [Getting started](#getting-started)
-* [Learn more](#learn-more)
-* [Challenge me](#challenge-me)
-
-## Getting started
-
-### Why license research data?
+{% include start.md text="Why license research data?" %}
 
 Consider this scenario: You’ve found a dataset you (or your client) is
 interested in.  You’ve downloaded it. Excellent!  But do you know what
@@ -61,17 +43,12 @@ and cited.
 which may have commercial value to others - what license would you
 apply?
 
-Do you have a question?  Want to share a resource?
-- Post to the [Data Librarians Slack group](https://tiny.cc/data-librarians) to connect with the community.
-- Tweet to [@ardc_au](https://twitter.com/ARDC_AU) using hashtag #23things
-
+{% include get-help.md %}
 
 Go to [Thing 10](thing-10.md)
 Sharing sensitive data or to [All Things](index.md)
 
-## Learn more 
-
-### Data licenses: unlock data for innovation
+{% include learn.md text="Data licenses: unlock data for innovation" %}
 
 Enabling reuse of data can speed up research and innovation.  Licensing
 is critical to enabling data reuse.
@@ -104,16 +81,12 @@ and Innovation Agenda](http://www.innovation.gov.au/page/agenda)?\
 Does your institution have a policy or guidelines around data
 licensing?
 
-Do you have a question?  Want to share a resource?
-- Post to the [Data Librarians Slack group](https://tiny.cc/data-librarians) to connect with the community.
-- Tweet to [@ardc_au](https://twitter.com/ARDC_AU) using hashtag #23things
+{% include get-help.md %}
 
 Go to [Thing 10](thing-10.md)
 Sharing sensitive data or to [All Things](index.md)
 
-## Challenge me
-
-### Data licensing in practice
+{% include challenge.md text="Data licensing in practice" %}
 
 Not all research data that is shared is licensed for reuse. It should
 be!
@@ -133,9 +106,7 @@ be!
 **Consider:** Assigning Open Licenses is not routine. Suggest one tip
 for encouraging uptake of 'open' licensing.
 
-Do you have a question?  Want to share a resource?
-- Post to the [Data Librarians Slack group](https://tiny.cc/data-librarians) to connect with the community.
-- Tweet to [@ardc_au](https://twitter.com/ARDC_AU) using hashtag#23things
+{% include get-help.md %}
 
 Go to [Thing 10](thing-10.md)
 Sharing sensitive data or to [All Things](index.md)


### PR DESCRIPTION
@mpfl for your consideration. This PR breaks out a number of repeated elements to make them easier to be consistent across the things, but also easier to update. It also updates the front matter.

1. add an _includes directory:
 for the templates :-)
2. add _includes/get-help.md:
 Standard "get help" text. It could be modified to add the credly badges  back in later if you like. This text gets repeated so often this is a no brainer.
3. add toc.md:
 A table of contents. This adds nav links to the toc and expects a little blurb for each section. This might need to be modified to handle some of the weirder things.
4. add start.md, learn.md, challenge.md:
 These are little bits of template to standardise the sections. This bit is less necessary, but it does help to ensure that the same styling/conventions apply across each document. Up you whether you keep this.
5. Lots of changes to front matter:
 a. tidy the description, including identifying the thing within it
 b. remove unnecessary elements (many of which could be specified in the config file, if even relevant).
 c. add a 'thing' variable to be used for all sorts of things (a navigation PR is coming that uses this)
 d. update the author
 e. capture the categories that each thing falls under. My intention is to add a little template for the related sections at the end of the document using this metadata.
6. remove the title from the content
 This should be specified in the front matter, and then exposed in the document template 

Merge whatever parts of this suit you.